### PR TITLE
(1) vectorized row-level calculations (2) add link cost discount to parameters.yaml (3) changed find_stops to fix a timestamp interpolation problem in find_route

### DIFF
--- a/map_matching/parameters.yaml
+++ b/map_matching/parameters.yaml
@@ -1,5 +1,5 @@
 geoprocessing parameters:
-  buffer size: 0.0016 #Buffer around the links to capture links likely used. Unit is degrees
+  buffer size: 0.0005 #Buffer around the links to capture links likely used. Unit is degrees
                       # Each 0.0001 correspond to approximately 11m (36ft) in the radius of the buffer
   azimuth tolerance: 22.5  # In case the network and the GPS data have azimuths, this is the tolerance to be used to
                            # to define if a GPS ping could have used a certain link
@@ -20,7 +20,7 @@ nodes file fields:
 
 data quality:
   max_speed: 130    # in kmph
-  max_speed_time: 120      # in seconds   --> time that the truck needs to be above the speed limit to be scraped
+  max_speed_time: 300      # in seconds   --> time that the truck needs to be above the speed limit to be scraped
   minimum_pings: 20 # Minimum number of pings that the vehicle needs to have to be considered valid
   minimum_coverage: 2 # Minimum diagonal of the Bounding box (km) defined by the GPS pings to be considered a valid vehicle
 
@@ -36,6 +36,10 @@ stops parameters:
 # Camargo, Hong and Livshits (2017)
   Delivery stop:
     stopped speed: 8  # in km/h
-    min time stopped: 300 # 5*60 in seconds   --> minimum stopped time to be considered
+    min time stopped: 180 # 5*60 in seconds   --> minimum stopped time to be considered
     max time stopped: 14400 # 4*60*60 in seconds   --> maximum stopped time to be considered
     max stop coverage: 0.8 # in kilometers
+
+map matching:
+# map matching related parameters
+  cost discount: 20 # possibly used link cost reduction ratio

--- a/map_matching/parameters.yaml
+++ b/map_matching/parameters.yaml
@@ -1,5 +1,5 @@
 geoprocessing parameters:
-  buffer size: 0.0005 #Buffer around the links to capture links likely used. Unit is degrees
+  buffer size: 0.0016 #Buffer around the links to capture links likely used. Unit is degrees
                       # Each 0.0001 correspond to approximately 11m (36ft) in the radius of the buffer
   azimuth tolerance: 22.5  # In case the network and the GPS data have azimuths, this is the tolerance to be used to
                            # to define if a GPS ping could have used a certain link
@@ -20,7 +20,7 @@ nodes file fields:
 
 data quality:
   max_speed: 130    # in kmph
-  max_speed_time: 300      # in seconds   --> time that the truck needs to be above the speed limit to be scraped
+  max_speed_time: 120      # in seconds   --> time that the truck needs to be above the speed limit to be scraped
   minimum_pings: 20 # Minimum number of pings that the vehicle needs to have to be considered valid
   minimum_coverage: 2 # Minimum diagonal of the Bounding box (km) defined by the GPS pings to be considered a valid vehicle
 
@@ -36,7 +36,7 @@ stops parameters:
 # Camargo, Hong and Livshits (2017)
   Delivery stop:
     stopped speed: 8  # in km/h
-    min time stopped: 180 # 5*60 in seconds   --> minimum stopped time to be considered
+    min time stopped: 300 # 5*60 in seconds   --> minimum stopped time to be considered
     max time stopped: 14400 # 4*60*60 in seconds   --> maximum stopped time to be considered
     max stop coverage: 0.8 # in kilometers
 


### PR DESCRIPTION
(1) vectorized several row-level apply functions in dataframe for the performance. 
(2) added link cost discount variable to parameters.yaml instead of having it hard-coded within **find_route**.
(3) replaced first stop duration of -99999999 with 0 in **Maximum space** method and in the special case of **Delivery stop** method. Reason behind: This was causing some problems in **find_route** during timestamp interpolation where the stop timestamp and its duration are used. The arbitrary negative duration (-99999999) will bring the first trip's starts time forward three years by mistake because _leave timestamp of a stop is stop time + stop duration_. I think there are two easy ways to fix it: one is adding a condition in **find_route** to make sure when the duration is -9999999, don't just add that up to the stop timestamp. The other way (as used in this commit) is just replacing -9999999 with 0. Let me know if you notice this may cause other troubles.